### PR TITLE
Realtime export of payload data in KML format.

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -23,6 +23,7 @@
 #include "urlencode.h"
 #include "base64.h"
 #include "ssdv.h"
+#include "kml.h"
 #include "global.h"
 
 
@@ -586,6 +587,7 @@ void LoadConfigFile()
 	Config.ftpUser[0] = '\0';
 	Config.ftpPassword[0] = '\0';
 	Config.ftpFolder[0] = '\0';
+	Config.EnableKML = 0;
 	
 	if ((fp = fopen(filename, "r")) == NULL)
 	{
@@ -603,6 +605,8 @@ void LoadConfigFile()
 	ReadString(fp, "ftpUser", Config.ftpUser, sizeof(Config.ftpUser), 0);
 	ReadString(fp, "ftpPassword", Config.ftpPassword, sizeof(Config.ftpPassword), 0);
 	ReadString(fp, "ftpFolder", Config.ftpFolder, sizeof(Config.ftpFolder), 0);	
+
+	ReadBoolean(fp, "EnableKML", 0, &Config.EnableKML);
 
 	for (Channel=0; Channel<=1; Channel++)
 	{
@@ -1070,6 +1074,12 @@ int main(int argc, char **argv)
 							DoPositionCalcs(Channel);
 							
 							Config.LoRaDevices[Channel].TelemetryCount++;
+							if (Config.EnableKML)
+								UpdatePayloadKML(Config.LoRaDevices[Channel].Payload, Config.LoRaDevices[Channel].Seconds, 
+									Config.LoRaDevices[Channel].Latitude, Config.LoRaDevices[Channel].Longitude, 
+									Config.LoRaDevices[Channel].Altitude);
+
+
 
 							Message[strlen(Message+1)] = '\0';
 							LogMessage("Ch %d: %s\n", Channel, Message+1);
@@ -1111,6 +1121,12 @@ int main(int argc, char **argv)
 							DoPositionCalcs(Channel);
 							
 							Config.LoRaDevices[Channel].TelemetryCount++;
+							if (Config.EnableKML)
+								UpdatePayloadKML(Payloads[SourceID].Payload, Config.LoRaDevices[Channel].Seconds, 
+									Config.LoRaDevices[Channel].Latitude, Config.LoRaDevices[Channel].Longitude, 
+									Config.LoRaDevices[Channel].Altitude);
+
+
 
 							LogMessage("Ch %d: Sender %d Source %d (%s) Position %8.5lf, %8.5lf, %05u\n",
 								Channel,

--- a/global.h
+++ b/global.h
@@ -40,6 +40,7 @@ struct TConfig
 	char ftpPassword[32];
 	char ftpFolder[64];
 	struct TLoRaDevice LoRaDevices[2];
+	int EnableKML;
 };
 
 extern struct TConfig Config;

--- a/kml.c
+++ b/kml.c
@@ -1,0 +1,125 @@
+/* RealTime KML export of the payload data */
+/* Based on https://ukhas.org.uk/using_google_earth */
+
+#include <unistd.h>  	// UNIX standard function definitions
+#include <stdio.h>   	// Standard input/output definitions
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "kml.h"
+#include "global.h"
+
+#define KML_LINE_SIZE 256 //Maximum size of a kml line
+
+/* KML file footer */
+const char footer_str[] = 
+	"        </coordinates>\n" \
+        "      </LineString>\n" \
+       	"    </Placemark>\n" \
+        "  </Document>\n" \
+       	"</kml>\n";
+
+/* Write the header of the KML file for the specified payload */
+void writeHeader(FILE* fp, char * payload) {
+	fprintf(fp,"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+	fprintf(fp,"  <kml xmlns=\"http://www.opengis.net/kml/2.2\" xmlns:gx=\"http://www.google.com/kml/ext/2.2\" " );
+	fprintf(fp,"  xmlns:kml=\"http://www.opengis.net/kml/2.2\" xmlns:atom=\"http://www.w3.org/2005/Atom\">\n");
+	fprintf(fp,"  <Document>\n	<name>%s</name>\n", payload);
+	fprintf(fp,"    <open>1</open>\n");
+	fprintf(fp,"    <Placemark>\n");
+	fprintf(fp,"      <name>%s-track</name>\n", payload);
+	fprintf(fp,"      <LineString>\n");
+	fprintf(fp,"        <extrude>1</extrude>\n");
+	fprintf(fp,"        <tessellate>1</tessellate>\n");
+	fprintf(fp,"        <altitudeMode>absolute</altitudeMode>\n");
+	fprintf(fp,"        <coordinates>\n");
+
+}
+
+/* Write the footer of the KML file */
+void writeFooter(FILE* fp) {
+	fprintf(fp,"%s", footer_str);
+}
+
+/* Write the KML for refreshing the track of the specified payload */
+void writeRefreshKML(FILE* fp, char * payload) {
+	fprintf(fp,"<kml xmlns=\"http://earth.google.com/kml/2.0\">\n");
+	fprintf(fp,"  <Document>\n");
+	fprintf(fp,"    <NetworkLink>\n");
+	fprintf(fp,"      <name>%s</name>\n", payload);
+	fprintf(fp,"      <Url>\n");
+	fprintf(fp,"        <href>%s.kml</href>\n", payload);
+	fprintf(fp,"        <refreshMode>onInterval</refreshMode>\n");
+	fprintf(fp,"        <refreshInterval>5</refreshInterval>\n");
+	fprintf(fp,"      </Url>\n");
+	fprintf(fp,"    </NetworkLink>\n");
+	fprintf(fp,"  </Document>\n");
+	fprintf(fp,"</kml>\n");
+}
+
+/* Update the KML file of the payload with the specified data */
+void UpdatePayloadKML(char * payload, unsigned int seconds, double latitude, double longitude, unsigned int altitude) {
+	FILE * fp;
+	char filename[256];
+	char line[KML_LINE_SIZE];
+	struct stat st;
+	int res;
+
+	/* Discard empty positions */
+	if (latitude == 0.0 && longitude == 0.0)
+		return;	
+	/* Path to the KML file for this payload */
+	sprintf(filename, "%s.kml", payload);
+
+	/* Check if the KML exists already */
+	res = stat(filename, &st);
+
+	/* Prepare the KML line for the payload data */
+	snprintf(line, KML_LINE_SIZE, "          %f,%f,%d\n", 
+			longitude, latitude, altitude);
+
+	/* If the KML doesn't exists */
+	if (res < 0) {
+		/* Create a KML file which will refresh the payload KML at regular interval */
+		char filename_refresh[256];
+		FILE * fp_refresh;
+		sprintf(filename_refresh, "%s-refresh.kml", payload);
+		fp_refresh = fopen(filename_refresh, "w");
+		if (fp_refresh) {
+			writeRefreshKML(fp_refresh,payload);
+			fclose(fp_refresh);
+		} else {
+			LogMessage("Can't open %s file for writing\n", filename_refresh);
+		}
+		/* Create the KML file for the payload */
+		
+		fp = fopen(filename, "a");
+		if (!fp) {
+			LogMessage("Can't open %s file for writing\n", filename);
+			return;
+		} else {
+			LogMessage("Created %s file\n", filename);
+		}
+		/* Add the header, new data line and footer */
+		writeHeader(fp, payload);
+		fwrite(line, 1, strlen(line), fp);
+		writeFooter(fp);
+
+	} else {
+		/* KML already exists : update only the file with new data */
+		fp = fopen(filename, "r+");
+		if (!fp) {
+			LogMessage("Can't open %s file for writing\n", filename);
+			return;
+		}
+		/* Write new data just before the position of the footer in the KML */
+		fseek(fp, -strlen(footer_str), SEEK_END);
+		fwrite(line, 1, strlen(line), fp);
+		writeFooter(fp);
+		
+	}
+	fclose(fp);
+}
+
+

--- a/kml.h
+++ b/kml.h
@@ -1,0 +1,4 @@
+/* RealTime KML export of the payload data */
+/* Based on https://ukhas.org.uk/using_google_earth */
+
+void UpdatePayloadKML(char * payload, unsigned int seconds, double latitude, double longitude, unsigned int altitude);

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
-gateway: gateway.o urlencode.o base64.o ssdv.o ssdv.h global.h
-	cc -o gateway gateway.o urlencode.o base64.o ssdv.o -lm -lwiringPi -lwiringPiDev -lcurl -lncurses -lpthread
+gateway: gateway.o urlencode.o base64.o ssdv.o ssdv.h kml.o global.h
+	cc -o gateway gateway.o urlencode.o base64.o ssdv.o kml.o -lm -lwiringPi -lwiringPiDev -lcurl -lncurses -lpthread
 
 gateway.o: gateway.c global.h
 	gcc -c gateway.c
@@ -12,4 +12,7 @@ urlencode.o: urlencode.c
 
 base64.o: base64.c
 	gcc -c base64.c
+
+kml.o: kml.c kml.h global.h
+	gcc -c kml.c
 


### PR DESCRIPTION
This new feature enabled by EnableKML=Y in gateway.txt allow to export in a KML file <payload>.kml for each payload, updating in realtime the position in the track of the kml. A <payload>-refresh.kml is also automatically created for viewing in realtime the updated positions from google earth. 
This feature will be used in the chasecar when the internet connection is lost and will allow to have the payload position on a map even without internet connection.