### PR TITLE
Increase AFC hysteresis

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -464,7 +464,7 @@ int receiveMessage(int Channel, unsigned char *message)
 		
 		message[Bytes] = '\0';
 	
-		if(Config.LoRaDevices[Channel].AFC && fabs(FreqError)>0.1)
+		if(Config.LoRaDevices[Channel].AFC && fabs(FreqError)>0.5)
 		{
 			ReTune(Channel, FreqError/1000);
 		}


### PR DESCRIPTION
On todays flight (RPF-PITS-LORA) the frequency was being corrected more often than necessary. Increasing the hysteresis improved the behaviour.
