### PR TITLE
Warning fix found with scan-build:

### DIFF
--- a/ssdv.c
+++ b/ssdv.c
@@ -47,7 +47,8 @@ int UploadImagePackets(void)
 	CURLcode res;
 	char PostFields[1000], base64_data[512], json[32768], packet_json[1000];
 	struct curl_slist *headers = NULL;
-	int UploadedOK, base64_length;
+	int UploadedOK;
+	size_t base64_length;
 	char now[32];
 	time_t rawtime;
 	struct tm *tm;


### PR DESCRIPTION
ssdv.c:87:89: warning: passing argument 3 of ‘base64_encode’ from incompatible pointer type
    base64_encode(SSDVPacketArrays[SSDVSendArrayIndex].Packets[PacketIndex].Packet, 256, &base64_length, base64_data);