### PR TITLE
Add received frequency metadata to telemetry uploads to habitat

### DIFF
--- a/gateway.h
+++ b/gateway.h
@@ -1,7 +1,7 @@
 #ifndef _H_Gateway
 #define _H_Gateway
 
-int receiveMessage( int Channel, char *message );
+int receiveMessage( int Channel, char *message, double *RxFrequency );
 void hexdump_buffer( const char *title, const char *buffer,
                      const int len_buffer );
 void LogPacket( int Channel, int8_t SNR, int RSSI, double FreqError,

--- a/global.h
+++ b/global.h
@@ -86,6 +86,7 @@ typedef struct {
     short int Channel;
     char Telemetry[257];
     int Packet_Number;
+    double RxFrequency;
 } telemetry_t;
 
 typedef struct {

--- a/habitat.c
+++ b/habitat.c
@@ -105,10 +105,10 @@ void UploadTelemetryPacket( telemetry_t * t )
         char counter[10];
         sprintf( counter, "%d", t->Packet_Number );
 
-        // Create json with the base64 data in hex, the tracker callsign and the current timestamp
+        // Create json with the base64 data in hex, the tracker callsign, received frequency and the current timestamp
         sprintf( json,
-                 "{\"data\": {\"_raw\": \"%s\"},\"receivers\": {\"%s\": {\"time_created\": \"%s\",\"time_uploaded\": \"%s\"}}}",
-                 base64_data, Config.Tracker, now, now );
+                 "{\"data\": {\"_raw\": \"%s\"},\"receivers\": {\"%s\": {\"rig_info\": {\"frequency\":%.0f},\"time_created\": \"%s\",\"time_uploaded\": \"%s\"}}}",
+                 base64_data, Config.Tracker, t->RxFrequency * 1000000, now, now );
 
         // LogTelemetryPacket(json);
 


### PR DESCRIPTION
As requested in https://github.com/PiInTheSky/lora-gateway/issues/15

Tested today and seems to be working OK with X0 payload.

Note that I have defined out some RJH test functions for uploading from binary files as I don't know if these are still required and they would require modification to be compatible with my changes.
