### PR TITLE
Use procserv to run gateway as a background service

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,29 @@ There's nothing special about "calling mode" except that after a period (Calling
 There is no current standard claling channel.
 
 
-Use
-===
+Interactive use
+===============
 
 Run with:
 
 	sudo ./gateway
 
+Install as a Service
+====================
+
+Procserv can be used to run the gateway as a background service.
+
+First edit hab-lora-gateway.conf to reflect the path to your installation, then:
+
+	1. sudo cp hab-lora-gateway.conf /etc/
+	2. sudo cp hab-lora-gateway /etc/init.d/
+	3. sudo apt-get install procserv telnet
+	4. sudo update-rc.d hab-lora-gateway defaults
+	5. sudo service hab-lora-gateway start
+
+The gateway script can now be reached using telnet:
+
+	telnet localhost 50100
 
 Display
 =======

--- a/hab-lora-gateway
+++ b/hab-lora-gateway
@@ -1,0 +1,246 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          hab-lora-gateway
+# Required-Start:    $all
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: HAB LoRa Gateway
+# Description:       HAB LoRa Gateway - Part of the LoRa Balloon Tracking System - http://www.pi-in-the-sky.com/
+
+### END INIT INFO
+
+# chkconfig: 2345 98 2
+# description: shellbox service for spawning programs
+
+export PATH=$PATH:/usr/local/bin
+
+export HOSTNAME=$(hostname -s)
+
+exe=/usr/bin/procServ
+options="-k ^X --killsig 15 -x ^C -i ^D -c"
+prog=hab-lora-gateway
+params=
+conf=/etc/hab-lora-gateway.conf
+logdir=/var/log/$prog
+shells=/var/run/$prog
+chroot=/mnt/ramdisk
+
+if [ -d $chroot ]
+then
+  CHROOT="chroot $chroot"
+fi
+
+fail () {
+  echo $@
+  exit 1
+}
+
+echo_failure () {
+  echo " [failed]"
+}
+
+checkpid () {
+  [ -d /proc/$PID ] 
+}
+
+launch () {
+  if [ "$1" = "-reload" ]
+  then
+    reload=YES
+    shift
+  fi
+  temp=$(mktemp -p $(dirname $shells)) || fail "can't create temporary file"
+  while read PORT USER DIR COMMAND
+  do
+    # check for empty lines and comments
+    [[ $PORT == "" || $PORT == \#* ]] && continue
+    # check if already started shell is still alive
+    if LINE=$(grep "$PORT $USER $DIR $COMMAND" $shells 2> /dev/null)
+    then
+      PID=${LINE%% *}
+      if checkpid $PID
+      then
+        if [ -z "$reload" ] && [ -z "$*" ] || echo "$*" | grep -qE "(^|[[:space:]])$PORT([[:space:]]|$)"
+        then
+          echo "Already running: $PORT $USER $DIR $COMMAND"
+        fi
+        echo "$LINE" >> $temp
+        continue
+      fi
+    fi
+
+    # check if we have to start all shells or only this PORT
+    [ "$*" ] && echo "$*" | grep -qvE "(^|[[:space:]])$PORT([[:space:]]|$)" && continue
+
+    if [ -n "$logdir" ]
+    then
+      [ -d $logdir ] || mkdir -m 777 $logdir
+      LOG=$logdir/$PORT
+      rm -f $LOG
+    else
+      LOG=/dev/null
+    fi
+
+    # Wait for time to be sync before launching
+    while true; do /usr/sbin/ntp-wait -v;  if [ $? -eq 0 ]; then break; fi; sleep 2; done
+
+    # start shellbox as other user
+    echo -n Starting: $PORT $USER $DIR $COMMAND
+    export SHELLBOX=$HOSTNAME:$PORT
+    #pidfile=/var/run/procServ-$PORT.pid
+    pidfile=/tmp/procServ-$PORT.pid
+    rm -f $pidfile
+#    $exe -p $pidfile $options $DIR $params $PORT $COMMAND >> $LOG 2>&1 < /dev/null
+    $CHROOT su $USER -c "$exe -p $pidfile $options $DIR $params $PORT $COMMAND >> $LOG 2>&1 < /dev/null"
+    # check if starting worked or failed
+    sleep 1
+    if [ -e $pidfile ]
+    then
+      PID=$(<$pidfile)
+      echo "$PID $PORT $USER $DIR $COMMAND" >> $temp
+      echo
+    else
+      echo_failure
+      echo
+      cat $LOG
+    fi
+  done < $conf
+  mv $temp $shells
+  chmod 0644 $shells
+}
+
+start () {
+  [ -r $conf ] || fail "$conf not readable"
+  [ -x $exe ] || fail "$exe is not executable"
+  launch $*
+  touch /var/lock/$prog
+}
+
+stopshell() {
+  PID=$1
+  PORT=$2
+  shift
+  echo -n Stopping: $*
+  kill $PID 2> /dev/null || echo_failure
+  echo
+  if [ $logdir ]
+  then
+      echo -e "\n**** stopped ****" >> $logdir/$PORT
+  fi
+}
+
+stop () {
+  # anything to stop?
+  if [ ! -r $shells ]
+  then
+    echo "$prog: No shells started."
+    exit 0
+  fi
+  if [ -z "$1" ]
+  then
+    # kill all shellboxes
+    while read PID PORT ARGS
+    do
+      stopshell $PID $PORT $ARGS
+    done < $shells
+    rm -f $shells
+    rm -f /var/lock/$prog
+  else
+    # kill only selected shellboxes
+    temp=$(mktemp -p $(dirname $shells)) || fail "can't create temporary file"
+    while read PID PORT ARGS
+    do
+      echo "$*" | grep -qE "(^|[[:space:]])$PORT([[:space:]]|$)" && stopshell $PID $PORT $ARGS || echo "$PID $PORT $ARGS" >> $temp
+    done < $shells
+    mv $temp $shells
+    chmod 0644 $shells
+  fi
+}
+
+reload () {
+  echo "Reloading $conf: "
+  [ -r $conf ] || fail "not readable"
+  # anything to stop?
+  if [ -r $shells ]
+  then
+    #first kill all shells that are not configured any more
+    temp=$(mktemp -p $(dirname $shells)) || fail "can't create temporary file"
+    while read PID ARGS
+    do
+      while read PORT USER DIR COMMAND
+      do
+        if [ "$PORT $USER $DIR $COMMAND" = "$ARGS" ]
+        then
+          echo "Keeping: $ARGS"
+          echo "$PID $ARGS" >> $temp
+          continue 2
+        fi
+      done < $conf
+      stopshell $PID $PORT $ARGS
+    done < $shells
+    mv $temp $shells
+    chmod 0644 $shells
+  fi
+  #now start all new shells
+  sleep 1
+  launch -reload
+}
+
+status () {
+  [ -r $conf ] || fail "$conf not readable"
+  if [ "$1" = "-log" ]
+  then
+    log=YES
+    shift
+  fi
+  echo -e "pid\tport\tuser\tdir\t\t\tcommand"
+  while read PORT USER DIR CMD
+  do
+    # check for empty lines and comments
+    [[ $PORT == "" || $PORT == \#* ]] && continue
+
+    # check if we have to report all shells
+    [ "$*" ] &&  echo "$*" | grep -qvE "(^|[[:space:]])$PORT([[:space:]]|$)" && continue
+    
+    if [ "$logdir" -a "$log" ]
+    then
+      echo "-------------------------------------------------------------------"
+    fi
+    
+    if LINE=$(grep "$PORT $USER $DIR $CMD" $shells 2> /dev/null)
+    then 
+      PID=${LINE%% *}
+      if checkpid $PID
+      then
+        echo -n $PID
+      else
+        $SETCOLOR_FAILURE
+        echo -n DEAD
+        $SETCOLOR_NORMAL
+      fi
+    else
+      $SETCOLOR_FAILURE
+      echo -n STOPPED 
+      $SETCOLOR_NORMAL
+    fi
+    echo -e "\t$PORT\t$USER\t$DIR\t$CMD"
+    
+    if [ "$logdir" -a "$log" ]
+    then
+        grep '\*\*\*\*' $logdir/$PORT 2>/dev/null
+    fi
+  done < $conf
+}
+
+CMD=$1
+shift
+case "$CMD" in
+  (start)         start $*;;
+  (stop)          stop $*;;
+  (restart)       stop $*; sleep 1; start $*;; # kill all shells, then start again
+  (reread|reload) reload $*;; # reload shellbox.conf without killing too much
+  (status)        status $*;;
+  (*)             echo "Usage: $0 {start [ports]|stop [ports]|restart [ports]|reload|status [-log] [ports]}" ;;
+esac
+

--- a/hab-lora-gateway.conf
+++ b/hab-lora-gateway.conf
@@ -1,0 +1,6 @@
+#shellbox configuration file
+#Starts commands inside a "box" with a telnet-like server.
+#Contact the shell with: telnet <hostname> <port>
+#Syntax:
+#port  user     directory                 command       args
+50100  root /home/pi/lora-gateway    /usr/bin/env TERM="vt220" ./gateway


### PR DESCRIPTION
Two additional files and an update to README.md to allow the lora-gateway binary to be run as a background service, yet still allow the console to be viewed using telnet... which is what I had in mind when i opened issue #30  :)