### PR TITLE
Detection of RFM Configuration Faults

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -1310,8 +1310,8 @@ void setupRFM98( int Channel )
 
         if( digitalRead( Config.LoRaDevices[Channel].DIO5 ) == 0 )
         {
-            LogMessage("Warning: DIO5 pin is misconfigured on channel %d, Disabling.\n", Channel);
-            Config.LoRaDevices[Channel].InUse = false;
+            LogMessage("Error: DIO5 pin is misconfigured on Channel %d, Disabling.\n", Channel);
+            Config.LoRaDevices[Channel].InUse = 0;
             return;
         }
 
@@ -1325,8 +1325,9 @@ void setupRFM98( int Channel )
 
         if ( readRegister( Channel, REG_VERSION ) == 0x00 )
         {
-            LogMessage("Error: RFM not found on channel %d, Disabling.\n", Channel);
-            Config.LoRaDevices[Channel].InUse = false;
+            LogMessage("Error: RFM not found on Channel %d, Disabling.\n", Channel);
+            Config.LoRaDevices[Channel].InUse = 0;
+            return;
         }
 
         // LoRa mode 
@@ -2226,6 +2227,11 @@ int main( int argc, char **argv )
 
     setupRFM98( 0 );
     setupRFM98( 1 );
+
+    if(Config.LoRaDevices[0].InUse == 0 && Config.LoRaDevices[1].InUse == 0)
+    {
+        LogMessage("Warning: No Receiver Channels enabled!\n");
+    }
 
     ShowPacketCounts( 0 );
     ShowPacketCounts( 1 );

--- a/gateway.c
+++ b/gateway.c
@@ -1308,6 +1308,13 @@ void setupRFM98( int Channel )
         pinMode( Config.LoRaDevices[Channel].DIO0, INPUT );
         pinMode( Config.LoRaDevices[Channel].DIO5, INPUT );
 
+        if( digitalRead( Config.LoRaDevices[Channel].DIO5 ) == 0 )
+        {
+            LogMessage("Warning: DIO5 pin is misconfigured on channel %d, Disabling.\n", Channel);
+            Config.LoRaDevices[Channel].InUse = false;
+            return;
+        }
+
         wiringPiISR( Config.LoRaDevices[Channel].DIO0, INT_EDGE_RISING,
                      Channel > 0 ? &DIO0_Interrupt_1 : &DIO0_Interrupt_0 );
 

--- a/gateway.c
+++ b/gateway.c
@@ -64,6 +64,7 @@ uint8_t currentMode = 0x81;
 #define REG_FREQ_ERROR				0x28
 #define REG_DETECT_OPT				0x31
 #define	REG_DETECTION_THRESHOLD		0x37
+#define	REG_VERSION					0x42
 
 // MODES
 #define RF98_MODE_RX_CONTINUOUS     0x85
@@ -1313,6 +1314,12 @@ void setupRFM98( int Channel )
         if ( wiringPiSPISetup( Channel, 500000 ) < 0 )
         {
             exit_error("Failed to open SPI port.  Try loading spi library with 'gpio load spi'" );
+        }
+
+        if ( readRegister( Channel, REG_VERSION ) == 0x00 )
+        {
+            LogMessage("Error: RFM not found on channel %d, Disabling.\n", Channel);
+            Config.LoRaDevices[Channel].InUse = false;
         }
 
         // LoRa mode 

--- a/gateway.c
+++ b/gateway.c
@@ -1308,13 +1308,6 @@ void setupRFM98( int Channel )
         pinMode( Config.LoRaDevices[Channel].DIO0, INPUT );
         pinMode( Config.LoRaDevices[Channel].DIO5, INPUT );
 
-        if( digitalRead( Config.LoRaDevices[Channel].DIO5 ) == 0 )
-        {
-            LogMessage("Error: DIO5 pin is misconfigured on Channel %d, Disabling.\n", Channel);
-            Config.LoRaDevices[Channel].InUse = 0;
-            return;
-        }
-
         wiringPiISR( Config.LoRaDevices[Channel].DIO0, INT_EDGE_RISING,
                      Channel > 0 ? &DIO0_Interrupt_1 : &DIO0_Interrupt_0 );
 
@@ -1326,6 +1319,13 @@ void setupRFM98( int Channel )
         if ( readRegister( Channel, REG_VERSION ) == 0x00 )
         {
             LogMessage("Error: RFM not found on Channel %d, Disabling.\n", Channel);
+            Config.LoRaDevices[Channel].InUse = 0;
+            return;
+        }
+
+        if( digitalRead( Config.LoRaDevices[Channel].DIO5 ) == 0 )
+        {
+            LogMessage("Error: DIO5 pin is misconfigured on Channel %d, Disabling.\n", Channel);
             Config.LoRaDevices[Channel].InUse = 0;
             return;
         }


### PR DESCRIPTION
- Detect if DIO5 isn't correctly mapped (default level != high), warn and disables the channel.
- Detect if the RFM isn't responding (reg 0x42 == 0x00), warn and disables the channel.
- Warn if both receivers are disabled or unconfigured.

Neither check is foolproof, but they provide a level of detection suitable for most error cases (RFM not installed / DIO5 wrongly mapped to empty pin).