### PR TITLE
Addition of Metadata data structure & Uses.

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -286,7 +286,8 @@ void LogPacket( rx_metadata_t *Metadata, int Bytes, unsigned char MessageType )
             tm = localtime( &Metadata->Timestamp );
 
             fprintf( fp,
-                     "%02d:%02d:%02d"
+                     "%04d-%02d-%02d"
+                     " %02d:%02d:%02d"
                      " - Ch %d"
                      ", SNR %d"
                      ", RSSI %d"
@@ -299,6 +300,7 @@ void LogPacket( rx_metadata_t *Metadata, int Bytes, unsigned char MessageType )
                      ", Impl %d"
                      ", Bytes %d"
                      ", Type %02Xh\n",
+                     (tm->tm_year + 1900), (tm->tm_mon + 1), tm->tm_mday,
                      tm->tm_hour, tm->tm_min, tm->tm_sec,
                      Metadata->Channel,
                      Metadata->SNR,

--- a/gateway.c
+++ b/gateway.c
@@ -285,11 +285,33 @@ void LogPacket( rx_metadata_t *Metadata, int Bytes, unsigned char MessageType )
             struct tm *tm;
             tm = localtime( &Metadata->Timestamp );
 
-            /* TODO: Expand this from Metadata as per Issue #5 */
             fprintf( fp,
-                     "%02d:%02d:%02d - Ch %d, SNR %d, RSSI %d, FreqErr %.1lf, Bytes %d, Type %02Xh\n",
-                     tm->tm_hour, tm->tm_min, tm->tm_sec, Metadata->Channel, Metadata->SNR, Metadata->RSSI,
-                     Metadata->FrequencyError*1000, Bytes, MessageType );
+                     "%02d:%02d:%02d"
+                     " - Ch %d"
+                     ", SNR %d"
+                     ", RSSI %d"
+                     ", Freq %.1lf"
+                     ", FreqErr %.1lf"
+                     ", BW %.2lf"
+                     ", EC 4:%d"
+                     ", SF %d"
+                     ", LDRO %d"
+                     ", Impl %d"
+                     ", Bytes %d"
+                     ", Type %02Xh\n",
+                     tm->tm_hour, tm->tm_min, tm->tm_sec,
+                     Metadata->Channel,
+                     Metadata->SNR,
+                     Metadata->RSSI,
+                     Metadata->Frequency*1000, /* NB: in KHz */
+                     Metadata->FrequencyError*1000, /* NB: in KHz */
+                     Metadata->Bandwidth,
+                     Metadata->ErrorCoding,
+                     Metadata->SpreadingFactor,
+                     Metadata->LowDataRateOptimize,
+                     Metadata->ImplicitOrExplicit,
+                     Bytes,
+                     MessageType );
 
             fclose( fp );
         }

--- a/gateway.h
+++ b/gateway.h
@@ -1,11 +1,12 @@
 #ifndef _H_Gateway
 #define _H_Gateway
 
-int receiveMessage( int Channel, char *message );
+#include "global.h"
+
+int receiveMessage( int Channel, char *message, rx_metadata_t *Metadata );
 void hexdump_buffer( const char *title, const char *buffer,
                      const int len_buffer );
-void LogPacket( int Channel, int8_t SNR, int RSSI, double FreqError,
-                int Bytes, unsigned char MessageType );
+void LogPacket( rx_metadata_t *Metadata, int Bytes, unsigned char MessageType );
 void LogTelemetryPacket( char *Telemetry );
 void LogMessage( const char *format, ... );
 void ChannelPrintf( int Channel, int row, int column, const char *format,

--- a/global.h
+++ b/global.h
@@ -1,3 +1,6 @@
+#ifndef _H_Global
+#define _H_Global
+
 #include <curses.h>
 
 #define RUNNING 1               // The main program is running
@@ -105,9 +108,23 @@ struct TPayload
 } thread_shared_vars_t;
 
 typedef struct {
+    /* Rx Metadata */
     short int Channel;
+    time_t Timestamp;
+    double Frequency;
+    double FrequencyError;
+    int ImplicitOrExplicit;
+    double Bandwidth;
+    int ErrorCoding;
+    int SpreadingFactor;
+    int LowDataRateOptimize;
+    int SNR;
+    int RSSI;
+} rx_metadata_t;
+
+typedef struct {
     char Telemetry[257];
-    int Packet_Number;
+    rx_metadata_t Metadata;
 } telemetry_t;
 
 typedef struct {
@@ -128,3 +145,5 @@ extern struct TConfig Config;
 extern int SSDVSendArrayIndex;
 extern pthread_mutex_t ssdv_mutex;
  void LogMessage( const char *format, ... );
+
+#endif /* _H_Global */

--- a/habitat.c
+++ b/habitat.c
@@ -214,8 +214,6 @@ void *HabitatLoop( void *vars )
 
                 ChannelPrintf( t.Metadata.Channel, 6, 1, "Habitat" );
 
-                LogTelemetryPacket( t.Telemetry );
-
                 UploadTelemetryPacket( &t );
 
                 ChannelPrintf( t.Metadata.Channel, 6, 1, "       " );

--- a/habitat.c
+++ b/habitat.c
@@ -62,18 +62,22 @@ void UploadTelemetryPacket( telemetry_t * t )
         SHA256_CTX ctx;
         unsigned char hash[32];
         char doc_id[100];
-        char json[1000], now[32];
+        char json[1000], now[32], doc_time[32];
         char Sentence[512];
         struct curl_slist *headers = NULL;
         time_t rawtime;
-        struct tm *tm;
+        struct tm *tm, *doc_tm;
 		int retries;
 		long int http_resp;
 
-        // Get formatted timestamp
+        // Get formatted timestamp for now
         time( &rawtime );
         tm = gmtime( &rawtime );
         strftime( now, sizeof( now ), "%Y-%0m-%0dT%H:%M:%SZ", tm );
+
+        // Get formatted timestamp for doc timestamp
+        doc_tm = gmtime( &t->Metadata.Timestamp );
+        strftime( doc_time, sizeof( doc_time ), "%Y-%0m-%0dT%H:%M:%SZ", doc_tm );
 
         // So that the response to the curl PUT doesn't mess up my finely crafted display!
         curl_easy_setopt( curl, CURLOPT_WRITEFUNCTION, habitat_write_data );
@@ -102,13 +106,10 @@ void UploadTelemetryPacket( telemetry_t * t )
         sha256_final( &ctx, hash );
         hash_to_hex( hash, doc_id );
 
-        char counter[10];
-        sprintf( counter, "%d", t->Packet_Number );
-
         // Create json with the base64 data in hex, the tracker callsign and the current timestamp
         sprintf( json,
-                 "{\"data\": {\"_raw\": \"%s\"},\"receivers\": {\"%s\": {\"time_created\": \"%s\",\"time_uploaded\": \"%s\"}}}",
-                 base64_data, Config.Tracker, now, now );
+                 "{\"data\": {\"_raw\": \"%s\"},\"receivers\": {\"%s\": {\"time_created\": \"%s\",\"time_uploaded\": \"%s\",\"rig_info\": {\"frequency\":%.0f}}}}",
+                 base64_data, Config.Tracker, doc_time, now, (t->Metadata.Frequency + t->Metadata.FrequencyError) * 1000000 );
 
         // LogTelemetryPacket(json);
 
@@ -211,13 +212,13 @@ void *HabitatLoop( void *vars )
             {
                 // LogMessage ("%s\n", t.Telemetry);
 
-                ChannelPrintf( t.Channel, 6, 1, "Habitat" );
+                ChannelPrintf( t.Metadata.Channel, 6, 1, "Habitat" );
 
                 LogTelemetryPacket( t.Telemetry );
 
                 UploadTelemetryPacket( &t );
 
-                ChannelPrintf( t.Channel, 6, 1, "       " );
+                ChannelPrintf( t.Metadata.Channel, 6, 1, "       " );
 
                 total_packets++;
 


### PR DESCRIPTION
- Removed message queue test code - functionality was behind that of the main code path, and would have required updating for the other changes in this set.

- Added storage of at-time-of-receive-configuration in rx_metadata_t struct. This is copied into the queued telemetry_t structure when a Telemetry Packet is processed.

- Added upload of receiver frequency (with detected offset) to Habitat with payload telemetry ( Issue #15 ). Mostly ported from Pull Req #28 which has been tested by @dbrooke .

- Added logging of additional metadata parameters in packet.log (Issue #5  )

- Removed duplicate 'LogTelemetryPacket()' call in habitat thread. (Already called in ProcessTelemetryMessage)

~~Do **not** merge yet - This code has been compiled and run, but not been tested with a payload due to lack of available hardware. I'll get it running on the Farnham gateway and tested whenever the next flight goes up.~~