### PR TITLE
server.c: Initialise pointers to remove GCC warning on some optimisation levels

### DIFF
--- a/server.c
+++ b/server.c
@@ -52,7 +52,7 @@ void ProcessJSONClientLine(int connfd, char *line)
 	if (strchr(line, '=') != NULL)
 	{
 		// Setting
-		char *setting, *value, *saveptr;
+		char *setting, *value, *saveptr = NULL;
 	
 		setting = strtok_r(line, "=", &saveptr);
 		value = strtok_r( NULL, "\n", &saveptr);
@@ -62,7 +62,7 @@ void ProcessJSONClientLine(int connfd, char *line)
 	else if (strchr(line, ':') != NULL)
 	{
 		// Command with parameters
-		char *command, *value, *saveptr;
+		char *command, *value, *saveptr = NULL;
 	
 		command = strtok_r(line, ":", &saveptr);
 		value = strtok_r(NULL, "\n", &saveptr);


### PR DESCRIPTION
Compiling under debugger-friendly optimisation produces the following GCC warnings:

> gcc -Wall -Og -ggdb  -o server.o -c server.c
server.c: In function ‘ProcessJSONClientLine’:
server.c:74:14: warning: ‘__s’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    channel = *value != '0';
              ^~~~~~
server.c:70:7: warning: ‘__s’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   if (strcasecmp(command, "send") == 0)
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
server.c:60:3: warning: ‘__s’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   SetConfigValue(setting, value);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
server.c:60:3: warning: ‘__s’ may be used uninitialized in this function [-Wmaybe-uninitialized]

I suspect these are a minor gcc bug, but harmlessly initialising the 'saveptr' pointer removes the warnings.