### PR TITLE
gateway.c: Only change GCC packing for TBinaryPacket struct

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -173,7 +173,7 @@ int help_win_displayed = 0;
 
 pthread_mutex_t var = PTHREAD_MUTEX_INITIALIZER;
 
-#pragma pack(1)
+#pragma pack(push,1)
 
 struct TBinaryPacket {
     uint8_t PayloadIDs;
@@ -183,6 +183,8 @@ struct TBinaryPacket {
     float Longitude;
     uint16_t Altitude;
 };
+
+#pragma pack(pop)
 
 // Create pipes for inter proces communication 
 // GLOBAL AS CALLED FROM INTERRRUPT


### PR DESCRIPTION
Separating these minor code tweaks out as they're not really part of the HABpack changeset.

This caught me out when playing with structs at the bottom of gateway.c, couldn't work out why functions outside gateway.c were handling the same struct differently!

Instead this just changes the packing for the declaration of the binary packet struct, then changes it back.