### PR TITLE
Rename CSV OziMux to OziPlotter, Add JSON OziMux.

### DIFF
--- a/Sockets.md
+++ b/Sockets.md
@@ -5,7 +5,7 @@ The LoRa Gateway provides some socket interfaces, configurable in gateway.txt:
 - ServerPort - TCP/IP server socket, allowing a single client.  Sends status and packet information in JSON format.  Also allows for gateway settings (e.g. frequency) to be polled or changed. 
 - DataPort - TCP/IP server socket, allowing a single client.  Sends raw telemetry packets (e.g. $$...).
 - UDPPort - UDP client broadcast socket, sending raw telemetry.
-- OziPort - UDP client broadcast socket, sending basic telemetry reformatted as OziMux format.
+- OziPlotterPort - UDP client broadcast socket, sending basic telemetry reformatted as OziPlotter CSV format.
 
 
 

--- a/Sockets.md
+++ b/Sockets.md
@@ -6,6 +6,7 @@ The LoRa Gateway provides some socket interfaces, configurable in gateway.txt:
 - DataPort - TCP/IP server socket, allowing a single client.  Sends raw telemetry packets (e.g. $$...).
 - UDPPort - UDP client broadcast socket, sending raw telemetry.
 - OziPlotterPort - UDP client broadcast socket, sending basic telemetry reformatted as OziPlotter CSV format.
+- OziMuxPort - UDP client broadcast socket, sending basic telemetry reformatted as OziMux JSON format.
 
 
 

--- a/gateway.c
+++ b/gateway.c
@@ -932,6 +932,26 @@ void ProcessLineUKHAS(int Channel, char *Line)
                              Config.Payloads[PayloadIndex].Altitude);   
         UDPSend(OziSentence, Config.OziPlotterPort);
     }
+
+    // Send out to any OziMux clients
+    if (Config.OziMuxPort > 0)
+    {
+        char OziSentence[512];
+        snprintf(OziSentence, 511,
+            "{\"type\":\"PAYLOAD_TELEMETRY\""
+            ",\"callsign\":\"%s\""
+            ",\"time_string\":\"%s\""
+            ",\"latitude\":\"%lf\""
+            ",\"longitude\":\"%lf\""
+            ",\"altitude\":\"%d\"}",
+            Config.Payloads[PayloadIndex].Payload,
+            Config.Payloads[PayloadIndex].Time,
+            Config.Payloads[PayloadIndex].Latitude,
+            Config.Payloads[PayloadIndex].Longitude,
+            Config.Payloads[PayloadIndex].Altitude
+        );
+        UDPSend(OziSentence, Config.OziMuxPort);
+    }
 }
 
 void ProcessLineHABpack(int Channel, received_t *Received)

--- a/gateway.c
+++ b/gateway.c
@@ -979,6 +979,14 @@ void ProcessLineHABpack(int Channel, received_t *Received)
                              Config.Payloads[PayloadIndex].Altitude);   
         UDPSend(OziSentence, Config.OziPlotterPort);
     }
+
+    // Send out to any OziMux clients
+    if (Config.OziMuxPort > 0)
+    {
+        char OziSentence[512];
+        Habpack_Telem_JSON(Received, OziSentence, 511);  
+        UDPSend(OziSentence, Config.OziMuxPort);
+    }
 }
 
 
@@ -1697,9 +1705,11 @@ void LoadConfigFile(void)
     RegisterConfigInteger(MainSection, -1, "DataPort", &Config.DataPort, NULL);			// Raw data server
     RegisterConfigInteger(MainSection, -1, "UDPPort", &Config.UDPPort, NULL);			// UDP Broadcast socket (raw data)
     RegisterConfigInteger(MainSection, -1, "OziPlotterPort", &Config.OziPlotterPort, NULL);			// UDP Broadcast socket (OziPlotter format)
+    RegisterConfigInteger(MainSection, -1, "OziMuxPort", &Config.OziMuxPort, NULL);         // UDP Broadcast socket (OziMux format)
 	
 	if (Config.UDPPort > 0) LogMessage("UDP Broadcast of raw packets on port %d\n", Config.UDPPort);
 	if (Config.OziPlotterPort > 0) LogMessage("UDP Broadcast of OziPlotter packets on port %d\n", Config.OziPlotterPort);
+    if (Config.OziMuxPort > 0) LogMessage("UDP Broadcast of OziMux packets on port %d\n", Config.OziMuxPort);
 	
 	// Timeout for HAB Telnet uplink
 	Config.HABTimeout = 4000;

--- a/gateway.c
+++ b/gateway.c
@@ -921,8 +921,8 @@ void ProcessLineUKHAS(int Channel, char *Line)
                   Config.Payloads[PayloadIndex].Longitude,
                   Config.Payloads[PayloadIndex].Altitude);
 
-    // Send out to any OziMux clients
-    if (Config.OziPort > 0)
+    // Send out to any OziPlotter clients
+    if (Config.OziPlotterPort > 0)
     {
         char OziSentence[200];
         sprintf(OziSentence, "TELEMETRY,%s,%lf,%lf,%d\n", 
@@ -930,7 +930,7 @@ void ProcessLineUKHAS(int Channel, char *Line)
                              Config.Payloads[PayloadIndex].Latitude,
                              Config.Payloads[PayloadIndex].Longitude,
                              Config.Payloads[PayloadIndex].Altitude);   
-        UDPSend(OziSentence, Config.OziPort);
+        UDPSend(OziSentence, Config.OziPlotterPort);
     }
 }
 
@@ -968,8 +968,8 @@ void ProcessLineHABpack(int Channel, received_t *Received)
                   Config.Payloads[PayloadIndex].Longitude,
                   Config.Payloads[PayloadIndex].Altitude);
 
-    // Send out to any OziMux clients
-    if (Config.OziPort > 0)
+    // Send out to any OziPlotter clients
+    if (Config.OziPlotterPort > 0)
     {
         char OziSentence[200];
         sprintf(OziSentence, "TELEMETRY,%s,%lf,%lf,%d\n", 
@@ -977,7 +977,7 @@ void ProcessLineHABpack(int Channel, received_t *Received)
                              Config.Payloads[PayloadIndex].Latitude,
                              Config.Payloads[PayloadIndex].Longitude,
                              Config.Payloads[PayloadIndex].Altitude);   
-        UDPSend(OziSentence, Config.OziPort);
+        UDPSend(OziSentence, Config.OziPlotterPort);
     }
 }
 
@@ -1696,10 +1696,10 @@ void LoadConfigFile(void)
     RegisterConfigInteger(MainSection, -1, "HABPort", &Config.HABPort, NULL);			// Telnet server
     RegisterConfigInteger(MainSection, -1, "DataPort", &Config.DataPort, NULL);			// Raw data server
     RegisterConfigInteger(MainSection, -1, "UDPPort", &Config.UDPPort, NULL);			// UDP Broadcast socket (raw data)
-    RegisterConfigInteger(MainSection, -1, "OziPort", &Config.OziPort, NULL);			// UDP Broadcast socket (OziMux format)
+    RegisterConfigInteger(MainSection, -1, "OziPlotterPort", &Config.OziPlotterPort, NULL);			// UDP Broadcast socket (OziPlotter format)
 	
 	if (Config.UDPPort > 0) LogMessage("UDP Broadcast of raw packets on port %d\n", Config.UDPPort);
-	if (Config.OziPort > 0) LogMessage("UDP Broadcast of OziMux packets on port %d\n", Config.OziPort);
+	if (Config.OziPlotterPort > 0) LogMessage("UDP Broadcast of OziPlotter packets on port %d\n", Config.OziPlotterPort);
 	
 	// Timeout for HAB Telnet uplink
 	Config.HABTimeout = 4000;

--- a/global.h
+++ b/global.h
@@ -148,7 +148,7 @@ typedef struct {
 } rx_metadata_t;
 
 /* HABpack Telemetry Storage */
-typedef enum { HB_VALUE_INTEGER, HB_VALUE_REAL } HB_Value_Type;
+typedef enum { HB_VALUE_INTEGER, HB_VALUE_REAL, HB_VALUE_STRING } HB_Value_Type;
 typedef struct habpack_telem_linklist_entry {
     uint32_t type;
     char name[32];
@@ -156,6 +156,7 @@ typedef struct habpack_telem_linklist_entry {
     union {
         int64_t integer;
         double real;
+        char *string;
     } value;
     struct habpack_telem_linklist_entry *next;
 } habpack_telem_linklist_entry_t;

--- a/global.h
+++ b/global.h
@@ -117,6 +117,7 @@ struct TConfig
 	int ServerPort;				// JSON port for telemetry, settings
 	int UDPPort;				// UDP Broadcast port for raw received data packets
 	int OziPlotterPort;			// UDP Broadcast port for OziPlotter formatted packets
+	int OziMuxPort;				// UDP Broadcast port for OziMux formatted packets
 	int HABPort;				// Telnet style port for comms with HAB
 	int HABTimeout;				// Timeout in ms for telnet uplink
 	int HABChannel;				// LoRa Channel for uplink

--- a/global.h
+++ b/global.h
@@ -116,7 +116,7 @@ struct TConfig
 	int InternetLED;
 	int ServerPort;				// JSON port for telemetry, settings
 	int UDPPort;				// UDP Broadcast port for raw received data packets
-	int OziPort;				// UDP Broadcast port for OziMux formatted packets
+	int OziPlotterPort;			// UDP Broadcast port for OziPlotter formatted packets
 	int HABPort;				// Telnet style port for comms with HAB
 	int HABTimeout;				// Timeout in ms for telnet uplink
 	int HABChannel;				// LoRa Channel for uplink

--- a/habpack.c
+++ b/habpack.c
@@ -301,6 +301,65 @@ void Habpack_Telem_UKHAS_String(received_t *Received, char *ukhas_string, uint32
     );
 }
 
+void Habpack_Telem_JSON(received_t *Received, char *json_string, uint32_t max_length)
+{
+    uint32_t str_index;
+    habpack_telem_linklist_entry_t *walk_ptr;
+
+    str_index = snprintf(
+        json_string,
+        max_length,
+        "{\"type\":\"PAYLOAD_TELEMETRY\""
+    );
+
+    /* All other fields */
+    walk_ptr = Received->Telemetry.habpack_extra;
+    while(walk_ptr != NULL)
+    {
+        str_index += snprintf(
+            &json_string[str_index],
+            (max_length - str_index),
+            ",\"%s\":",
+            walk_ptr->name
+        );
+        if(walk_ptr->value_type == HB_VALUE_INTEGER)
+        {
+            str_index += snprintf(
+                &json_string[str_index],
+                (max_length - str_index),
+                "%"PRId64,
+                walk_ptr->value.integer
+            );
+        }
+        else if(walk_ptr->value_type == HB_VALUE_REAL)
+        {
+            str_index += snprintf(
+                &json_string[str_index],
+                (max_length - str_index),
+                "%f",
+                walk_ptr->value.real
+            );
+        }
+        else if(walk_ptr->value_type == HB_VALUE_STRING)
+        {
+            str_index += snprintf(
+                &json_string[str_index],
+                (max_length - str_index),
+                "\"%s\"",
+                walk_ptr->value.string
+            );
+        }
+
+        walk_ptr = walk_ptr->next;
+    }
+
+    str_index += snprintf(
+        &json_string[str_index],
+        (max_length - str_index),
+        "}"
+    );
+}
+
 void Habpack_Telem_Destroy(received_t *Received)
 {
     habpack_telem_linklist_entry_t *walk_ptr, *last_ptr;

--- a/habpack.h
+++ b/habpack.h
@@ -45,4 +45,6 @@
 int Habpack_Process_Message(received_t *Received);
 void Habpack_Telem_Destroy(received_t *Received);
 
+void Habpack_Telem_JSON(received_t *Received, char *json_string, uint32_t max_length);
+
 #endif /* __HABPACK_H__ */


### PR DESCRIPTION
- Renames OziPort -> OziPlotterPort
- Renames OziMux -> OziPlotter

- Adds JSON OziMux, using OziMuxPort config paramter, for UKHAS ASCII & HABpack Telemetry.

example output:

> {"type":"PAYLOAD_TELEMETRY","callsign":"CRAAG4","sentence_id":2344,"time":1525611801,"latitude":50.936135,"longitude":-1.388866,"altitude":28,"gnss_satellites":7,"voltage":1.225000}

Needs to be applied on top of #51.