### PR TITLE
Use LIFO circular buffer for Telemetry Upload

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -1021,8 +1021,9 @@ void ProcessTelemetryMessage(int Channel, received_t *Received)
                 received_t *queueReceived = malloc(sizeof(received_t));
                 if(queueReceived != NULL)
                 {
-                    /* WARNING: Doesn't copy linked-list :/ */
                     memcpy(queueReceived, Received, sizeof(received_t));
+                    /* We haven't copied the linked list, this'll be free()ed later, so remove pointer */
+                    queueReceived->Telemetry.habpack_extra = NULL;
 
                     /* Push pointer onto upload queue */
                     lifo_buffer_push(&Habitat_Upload_Buffer, (void *)queueReceived);

--- a/habitat.c
+++ b/habitat.c
@@ -49,7 +49,7 @@ void hash_to_hex( unsigned char *hash, char *line )
     line[64] = '\0';
 }
 
-void UploadTelemetryPacket( received_t * t )
+bool UploadTelemetryPacket( received_t * t )
 {
     CURL *curl;
     CURLcode res;
@@ -59,6 +59,7 @@ void UploadTelemetryPacket( received_t * t )
     curl = curl_easy_init(  );
     if ( curl )
     {
+        bool result;
         char url[200];
         char base64_data[1000];
         size_t base64_length;
@@ -142,7 +143,13 @@ void UploadTelemetryPacket( received_t * t )
 				if (http_resp != 201 && http_resp != 403 && http_resp != 409)
 				{
 					LogMessage("Unexpected HTTP response %ld for URL '%s'\n", http_resp, url);
+                    result = false;
 				}
+                else
+                {
+                    /* Everything performing nominally (even if we didn't successfully insert this time) */
+                    result = true;
+                }
 			}
 			else
 			{
@@ -150,6 +157,8 @@ void UploadTelemetryPacket( received_t * t )
 				LogMessage("Failed for URL '%s'\n", url);
 				LogMessage("curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
 				LogMessage("error: %s\n", curl_error);
+                /* Likely a network error, so return false to requeue */
+                result = false;
 			}
 			
 			if (http_resp == 409)
@@ -163,6 +172,13 @@ void UploadTelemetryPacket( received_t * t )
         // always cleanup
         curl_slist_free_all( headers );
         curl_easy_cleanup( curl );
+
+        return result;
+    }
+    else
+    {
+        /* CURL error, return false so we requeue */
+        return false;
     }
 }
 
@@ -180,23 +196,33 @@ void *HabitatLoop( void *vars )
 
             if(dequeued_telemetry_ptr != NULL)
             {
-                ChannelPrintf( dequeued_telemetry_ptr->Metadata.Channel, 6, 1, "Habitat" );
+                ChannelPrintf( dequeued_telemetry_ptr->Metadata.Channel, 6, 1, "Habitat (%d queued)", lifo_buffer_queued(&Habitat_Upload_Buffer) );
 
-                UploadTelemetryPacket( dequeued_telemetry_ptr );
+                if(UploadTelemetryPacket( dequeued_telemetry_ptr ))
+                {
+                    ChannelPrintf( dequeued_telemetry_ptr->Metadata.Channel, 6, 1, "                   " );
+                    free(dequeued_telemetry_ptr);
+                }
+                else
+                {
+                    /* Network / CURL Error, requeue packet */
+                    ChannelPrintf( dequeued_telemetry_ptr->Metadata.Channel, 6, 1, "Habitat Net Error! " );
 
-                ChannelPrintf( dequeued_telemetry_ptr->Metadata.Channel, 6, 1, "       " );
-
-                free(dequeued_telemetry_ptr);
+                    if(!lifo_buffer_requeue(&Habitat_Upload_Buffer, dequeued_telemetry_ptr))
+                    {
+                        /* Requeue failed, drop packet */
+                        free(dequeued_telemetry_ptr);
+                    }
+                }
             }
             else
             {
-                /* We've been asked to quit */
+                /* NULL returned: We've been asked to quit */
+                /* Don't bother free()ing stuff, as application is quitting */
                 break;
             }
         }
     }
-
-    LogMessage( "Habitat thread closing\n" );
 
     return NULL;
 }

--- a/habitat.c
+++ b/habitat.c
@@ -23,6 +23,9 @@
 #include "sha256.h"
 #include "wiringPi.h"
 #include "gateway.h"
+#include "lifo_buffer.h"
+
+extern lifo_buffer_t Habitat_Upload_Buffer;
 
 extern int telem_pipe_fd[2];
 extern pthread_mutex_t var;
@@ -79,19 +82,6 @@ void UploadTelemetryPacket( received_t * t )
         doc_tm = gmtime( &t->Metadata.Timestamp );
         strftime( doc_time, sizeof( doc_time ), "%Y-%0m-%0dT%H:%M:%SZ", doc_tm );
 
-        // So that the response to the curl PUT doesn't mess up my finely crafted display!
-        curl_easy_setopt( curl, CURLOPT_WRITEFUNCTION, habitat_write_data );
-
-        // Set the timeout
-        curl_easy_setopt( curl, CURLOPT_TIMEOUT, 15 );
-
-        // RJH capture http errors and report
-        // curl_easy_setopt( curl, CURLOPT_FAILONERROR, 1 );
-        curl_easy_setopt( curl, CURLOPT_ERRORBUFFER, curl_error );
-
-        // Avoid curl library bug that happens if above timeout occurs (sigh)
-        curl_easy_setopt( curl, CURLOPT_NOSIGNAL, 1 );
-
         // Grab current telemetry string and append a linefeed
         sprintf( Sentence, "%s\n", t->UKHASstring );
 
@@ -111,11 +101,21 @@ void UploadTelemetryPacket( received_t * t )
                  "{\"data\": {\"_raw\": \"%s\"},\"receivers\": {\"%s\": {\"time_created\": \"%s\",\"time_uploaded\": \"%s\",\"rig_info\": {\"frequency\":%.0f}}}}",
                  base64_data, Config.Tracker, doc_time, now, (t->Metadata.Frequency + t->Metadata.FrequencyError) * 1000000 );
 
-        // LogTelemetryPacket(json);
-
-
         // Set the URL that is about to receive our PUT
         sprintf( url, "http://habitat.habhub.org/habitat/_design/payload_telemetry/_update/add_listener/%s", doc_id);
+
+        // So that the response to the curl PUT doesn't mess up my finely crafted display!
+        curl_easy_setopt( curl, CURLOPT_WRITEFUNCTION, habitat_write_data );
+
+        // Set the timeout
+        curl_easy_setopt( curl, CURLOPT_TIMEOUT, 15 );
+
+        // RJH capture http errors and report
+        // curl_easy_setopt( curl, CURLOPT_FAILONERROR, 1 );
+        curl_easy_setopt( curl, CURLOPT_ERRORBUFFER, curl_error );
+
+        // Avoid curl library bug that happens if above timeout occurs (sigh)
+        curl_easy_setopt( curl, CURLOPT_NOSIGNAL, 1 );
 
         // Set the headers
         headers = NULL;
@@ -169,64 +169,32 @@ void UploadTelemetryPacket( received_t * t )
 
 void *HabitatLoop( void *vars )
 {
-
     if ( Config.EnableHabitat )
     {
-        thread_shared_vars_t *htsv;
-        htsv = vars;
-        received_t t;
-        int packets = 0;
-        unsigned long total_packets = 0;
+        received_t *dequeued_telemetry_ptr;
 
-        int i = 1;
-
-        // Keep looping until the parent quits and there are no more packets to 
-        // send to habitat.
-        while ( ( htsv->parent_status == RUNNING ) || ( packets > 0 ) )
+        // Keep looping until the parent quits
+        while ( true )
         {
+            dequeued_telemetry_ptr = lifo_buffer_waitpop(&Habitat_Upload_Buffer);
 
-            //THis is neded for some reason habitat thread has a pthread_mutex_lock set 
-            // and this removes it 
-            if ( i )
+            if(dequeued_telemetry_ptr != NULL)
             {
-                // pthread_mutex_lock(&var);
-                pthread_mutex_unlock( &var );
-                i = 0;
-            }
-            if ( htsv->packet_count > total_packets )
-            {
-                packets = read( telem_pipe_fd[0], &t, sizeof( t ) );
+                ChannelPrintf( dequeued_telemetry_ptr->Metadata.Channel, 6, 1, "Habitat" );
+
+                UploadTelemetryPacket( dequeued_telemetry_ptr );
+
+                ChannelPrintf( dequeued_telemetry_ptr->Metadata.Channel, 6, 1, "       " );
+
+                free(dequeued_telemetry_ptr);
             }
             else
             {
-                packets = 0;
-                // pthread_mutex_unlock(&var);
-
-                // If we have have a rollover after processing 4294967295 packets 
-                if ( htsv->packet_count < total_packets )
-                    total_packets = 0;
-
+                /* We've been asked to quit */
+                break;
             }
-
-            if ( packets )
-            {
-                // LogMessage ("%s\n", t.Telemetry);
-
-                ChannelPrintf( t.Metadata.Channel, 6, 1, "Habitat" );
-
-                UploadTelemetryPacket( &t );
-
-                ChannelPrintf( t.Metadata.Channel, 6, 1, "       " );
-
-                total_packets++;
-
-            }
-			delay(100);			// Don't eat too much CPU
         }
     }
-
-    close( telem_pipe_fd[0] );
-    close( telem_pipe_fd[1] );
 
     LogMessage( "Habitat thread closing\n" );
 

--- a/lifo_buffer.c
+++ b/lifo_buffer.c
@@ -1,0 +1,115 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "lifo_buffer.h"
+
+void lifo_buffer_init(lifo_buffer_t *buf, uint32_t length)
+{    
+    pthread_mutex_init(&buf->Mutex, NULL);
+    pthread_cond_init(&buf->Signal, NULL);
+    
+    pthread_mutex_lock(&buf->Mutex);
+    buf->Head = 0;
+    buf->Tail = 0;
+    buf->Length = length;
+    buf->Data = malloc(length * sizeof(void *));
+    buf->Quit = false;
+    pthread_mutex_unlock(&buf->Mutex);
+}
+
+/* Lossy when buffer is full */
+void lifo_buffer_push(lifo_buffer_t *buf, void *data_ptr)
+{
+    pthread_mutex_lock(&buf->Mutex);
+
+    /* If no space, remove oldest from bottom of the queue by advancing Tail */
+    if(buf->Head==(buf->Tail-1) || (buf->Head==(buf->Length-1) && buf->Tail==0))
+    {
+        if(buf->Tail==(buf->Length-1))
+            buf->Tail=0;
+        else
+            buf->Tail++;
+    }
+
+    if(buf->Head==(buf->Length-1))
+        buf->Head=0;
+    else
+        buf->Head++;
+
+    buf->Data[buf->Head] = data_ptr;
+    
+    pthread_cond_signal(&buf->Signal);
+
+    pthread_mutex_unlock(&buf->Mutex);
+}
+
+/* Returns NULL when unsuccessful */
+void *lifo_buffer_pop(lifo_buffer_t *buf)
+{
+    void *result;
+    
+    pthread_mutex_lock(&buf->Mutex);
+    if(buf->Head!=buf->Tail)
+    {
+        result = buf->Data[buf->Head];
+
+        if(buf->Head==0)
+            buf->Head=(buf->Length-1);
+        else
+            buf->Head--;
+    
+        pthread_mutex_unlock(&buf->Mutex);
+    }
+    else
+    {
+        pthread_mutex_unlock(&buf->Mutex);
+        
+        result = NULL;
+    }
+
+    return result;
+}
+
+void *lifo_buffer_waitpop(lifo_buffer_t *buf)
+{    
+    void *result;
+
+    pthread_mutex_lock(&buf->Mutex);
+    
+    while(buf->Head==buf->Tail && !buf->Quit) /* If buffer is empty */
+    {
+        /* Mutex is atomically unlocked on beginning waiting for signal */
+        pthread_cond_wait(&buf->Signal, &buf->Mutex);
+        /* and locked again on resumption */
+    }
+
+    if(buf->Quit)
+    {
+        return NULL;
+    }
+    
+    result = buf->Data[buf->Head];
+
+    if(buf->Head==0)
+        buf->Head=(buf->Length-1);
+    else
+        buf->Head--;
+
+    pthread_mutex_unlock(&buf->Mutex);
+    
+    return result;
+}
+
+void lifo_buffer_quitwait(lifo_buffer_t *buf)
+{
+    pthread_mutex_lock(&buf->Mutex);
+
+    buf->Quit = true;
+    
+    pthread_cond_signal(&buf->Signal);
+
+    pthread_mutex_unlock(&buf->Mutex);
+}

--- a/lifo_buffer.h
+++ b/lifo_buffer.h
@@ -1,0 +1,30 @@
+#ifndef __LIFO_BUFFER_H__
+#define __LIFO_BUFFER_H__
+
+#include <stdbool.h>
+#include <pthread.h>
+
+typedef struct
+{
+    /* Buffer Access Lock */
+    pthread_mutex_t Mutex;
+    /* New Data Signal */
+    pthread_cond_t Signal;
+    /* Whether the waiting thread should quit */
+    bool Quit;
+    /* Head and Tail Indexes */
+    uint32_t Head, Tail;
+    /* Data */
+    void **Data;
+    /* Data Length */
+    uint32_t Length;
+} lifo_buffer_t;
+
+/** Common functions **/
+void lifo_buffer_init(lifo_buffer_t *buf, uint32_t length);
+void lifo_buffer_push(lifo_buffer_t *buf, void *data_ptr);
+void *lifo_buffer_pop(lifo_buffer_t *buf);
+void *lifo_buffer_waitpop(lifo_buffer_t *buf);
+void lifo_buffer_quitwait(lifo_buffer_t *buf);
+
+#endif /* __LIFO_BUFFER_H__*/

--- a/lifo_buffer.h
+++ b/lifo_buffer.h
@@ -22,9 +22,11 @@ typedef struct
 
 /** Common functions **/
 void lifo_buffer_init(lifo_buffer_t *buf, uint32_t length);
+uint32_t lifo_buffer_queued(lifo_buffer_t *buf);
 void lifo_buffer_push(lifo_buffer_t *buf, void *data_ptr);
 void *lifo_buffer_pop(lifo_buffer_t *buf);
 void *lifo_buffer_waitpop(lifo_buffer_t *buf);
 void lifo_buffer_quitwait(lifo_buffer_t *buf);
+bool lifo_buffer_requeue(lifo_buffer_t *buf, void *data_ptr);
 
 #endif /* __LIFO_BUFFER_H__*/


### PR DESCRIPTION
Instead of using a pipe, instead uses an allocated buffer of pointers.

In the case of network errors, the packet is added to the bottom of the buffer. Ideally it'd be re-added to the top but this way if habitat is rejecting a particular packet, then it doesn't clog the pipeline.

Independent to the 2x other pull reqs today.