### PR TITLE
Display activeFreq (with correction) Closes #54.

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -2283,7 +2283,7 @@ void SendUplinkMessage( int Channel )
 
 void displayChannel (int Channel) {
 
-    displayFrequency ( Channel, Config.LoRaDevices[Channel].Frequency );
+    displayFrequency ( Channel, Config.LoRaDevices[Channel].activeFreq );
 
     displayLoRaParameters( 
         Channel, 


### PR DESCRIPTION
Display activeFreq (with correction) rather than original Frequency when closing help screen.

Haven't tested behaviour with AFC - would be a good idea before merging.