### PR TITLE
Fix typos/formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The global options are:
 	
 	EnableHabitat=<Y/N>.  Enables uploading of telemetry packets to Habitat.
 	
-	EnableSondhub=<Y/N>.  Enables uploading of telemetry packets to the amateur Sondehub system.
+	EnableSondehub=<Y/N>.  Enables uploading of telemetry packets to the amateur Sondehub system.
 	
 	EnableSSDV=<Y/N>.  Enables uploading of SSDV image packets to the SSDV server.
 	

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The global options are:
 	
 	EnableHabitat=<Y/N>.  Enables uploading of telemetry packets to Habitat.
 	
-	EnableSondehub=<Y/N>.  Enables uploading of telemetry packets to the amateur Sondehub system.
+	EnableSondhub=<Y/N>.  Enables uploading of telemetry packets to the amateur Sondehub system.
 	
 	EnableSSDV=<Y/N>.  Enables uploading of SSDV image packets to the SSDV server.
 	
@@ -160,28 +160,26 @@ The global options are:
 	ActivityLED_0=<wiring pi pin>
 	ActivityLED_1=<wiring pi pin>.  These are used for LED status indicators. Useful for packaged gateways that don't have a monitor attached.
 
-
-​	
 and the channel-specific options are:
-​	
-​	frequency_<n>=<freq in MHz>.  This sets the frequency for LoRa module <n> (0 for first, 1 for second).  e.g. frequency_0=434.450
-​	
-​	PPM_<n>=<Parts per million offset of LoRa module.
-​	
-​	AFC_<n>=<Y/N>.  Enables or disables automatic frequency control (retunes by the frequency error of last received packet).
-​	
-​	mode_<n>=<mode>.  Sets the "mode" for the selected LoRa module.  This offers a simple way of setting the various
-​					LoRa parameters (SF etc.) in one go.  The modes are:
-​					
-​					0 = (normal for telemetry)	Explicit mode, Error coding 4:8, Bandwidth 20.8kHz, SF 11, Low data rate optimize on
-​					1 = (normal for SSDV) 		Implicit mode, Error coding 4:5, Bandwidth 20.8kHz,  SF 6, Low data rate optimize off
-​					2 = (normal for repeater)	Explicit mode, Error coding 4:8, Bandwidth 62.5kHz,  SF 8, Low data rate optimize off
-​					3 = (normal for fast SSDV)	Explicit mode, Error coding 4:6, Bandwidth 250kHz,   SF 7, Low data rate optimize off
-​					4 = Test mode not for normal use.
-​					5 = (normal for calling mode)	Explicit mode, Error coding 4:8, Bandwidth 41.7kHz, SF 11, Low data rate optimize off
-​					
-​	SF_<n>=<Spreading Factor>  e.g. SF_0=7
-​	
+
+	frequency_<n>=<freq in MHz>.  This sets the frequency for LoRa module <n> (0 for first, 1 for second).  e.g. frequency_0=434.450
+	
+	PPM_<n>=<Parts per million offset of LoRa module.
+	
+	AFC_<n>=<Y/N>.  Enables or disables automatic frequency control (retunes by the frequency error of last received packet).
+	
+	mode_<n>=<mode>.  Sets the "mode" for the selected LoRa module.  This offers a simple way of setting the various
+					LoRa parameters (SF etc.) in one go.  The modes are:
+					
+					0 = (normal for telemetry)	Explicit mode, Error coding 4:8, Bandwidth 20.8kHz, SF 11, Low data rate optimize on
+					1 = (normal for SSDV) 		Implicit mode, Error coding 4:5, Bandwidth 20.8kHz,  SF 6, Low data rate optimize off
+					2 = (normal for repeater)	Explicit mode, Error coding 4:8, Bandwidth 62.5kHz,  SF 8, Low data rate optimize off
+					3 = (normal for fast SSDV)	Explicit mode, Error coding 4:6, Bandwidth 250kHz,   SF 7, Low data rate optimize off
+					4 = Test mode not for normal use.
+					5 = (normal for calling mode)	Explicit mode, Error coding 4:8, Bandwidth 41.7kHz, SF 11, Low data rate optimize off
+					
+	SF_<n>=<Spreading Factor>  e.g. SF_0=7
+	
 	Bandwidth_<n>=<Bandwidth>.  e.g. Bandwidth_0=41K7.  Options are 7K8, 10K4, 15K6, 20K8, 31K25, 41K7, 62K5, 125K, 250K, 500K
 	
 	Implicit_<n>=<Y/N>.  e.g. Implicit_0=Y


### PR DESCRIPTION
Spotted a minor typo in README.md while figuring out why my gateway wasn't uploading to Sondehub. It had me checking the source to confirm whether the Configuration example or options section was correct. `EnableSondehub` appears to be the correct key.