### PR TITLE
Update sondehub.c to match temp and ext_temperature tags as used at grafana.v2.sondehub.org

### DIFF
--- a/sondehub.c
+++ b/sondehub.c
@@ -205,11 +205,11 @@ void ExtractFields(char *Telemetry, char *ExtractedFields)
 				break;
 
 				case 'A':	
-				sprintf(Value, "\"internal_temp\":%s,", token);
+				sprintf(Value, "\"temp\":%s,", token);
 				break;
 
 				case 'B':
-				sprintf(Value, "\"temp\":%s,", token);
+				sprintf(Value, "\"ext_temperature\":%s,", token);
 				break;
 
 				case 'C':	


### PR DESCRIPTION
Changing internal_temp to temp and temp to ext_temperature in order to match up with the tags used at https://grafana.v2.sondehub.org/