### PR TITLE
Port to lgpio as a wiringPi replacement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ EXE=gateway
 INDOPT= -bap -bl -blf -bli0 -brs -cbi0 -cdw -cs -ci4 -cli4 -i4 -ip0 -nbc -nce -lp -npcs -nut -pmt -psl -prs -ts4
 
 CC=gcc
-CFLAGS=-Wall -O3 #-std=c99 
-LDFLAGS= -lm -lwiringPi -lwiringPiDev -lcurl -lncurses -lpthread -lpaho-mqtt3c
+CFLAGS=-Wall -O3 #-std=c99
+LDFLAGS= -lm -llgpio -lcurl -lncurses -lpthread -lpaho-mqtt3c
 RM=rm
 
 %.o: %.c *.h     # combined w/ next line will compile recently changed .c files
@@ -23,7 +23,7 @@ $(EXE): $(OBJ)   # $(EXE) is dependent on all of the files in $(OBJ) to exist
 
 .PHONY : clean   # .PHONY ignores files named clean
 clean:
-	-$(RM) $(OBJ) 
+	-$(RM) $(OBJ)
 
 tidy:
 	indent $(INDOPT) $(SRC) $(HED)

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Enable SPI in raspi-config
 Dependencies
 ============
 
-	sudo apt-get install git libcurl4-openssl-dev libncurses5-dev  libssl-dev
-
+	sudo apt install git libcurl4-openssl-dev libncurses5-dev libssl-dev liblgpio-dev libpaho-mqtt-dev libpaho-mqtt1.3
 
 
 SSDV
@@ -48,34 +47,6 @@ Raspberry Pi OS no longer includes SSDV, so you must install SSDV from source as
 	cd ~
 	git clone https://github.com/fsphil/ssdv.git
 	cd ssdv
-	make
-	sudo make install
-
-
-
-
-WiringPi
-========
-
-Raspberry Pi OS no longer includes WiringPi, so you must install Wiring Pi from source as follows:
-	
-	cd ~
-	git clone https://github.com/WiringPi/WiringPi.git
-	cd WiringPi
-	./build
-
-
-
-MQTT
-=======
-
-MQTT support was added recently, and needs the following library installed::
-
-	cd ~ 
-	mkdir MQTTClients
-	cd MQTTClients
-	git clone https://github.com/janderholm/paho.mqtt.c.git
-	cd paho.mqtt.c
 	make
 	sudo make install
 
@@ -295,6 +266,10 @@ Many thanks to David Brooke for coding this feature and the AFC.
 
 Change History
 ==============
+
+## 12/04/2024 - V1.11.0
+    Port to kernel lgpio interface instead of wiringPi
+	Use apt provided mqtt libraries
 
 ## 08/10/2023 - V1.10.6
 	Use callsign for MQTT client ID

--- a/gateway-sample.txt
+++ b/gateway-sample.txt
@@ -18,10 +18,10 @@ LogPackets=Y
 CallingTimeout=60
 ServerPort=6004
 
-NetworkLED=22
-InternetLED=23
-ActivityLED_0=21
-ActivityLED_1=29
+NetworkLED=6
+InternetLED=13
+ActivityLED_0=5
+ActivityLED_1=24
 
 ##### Config CE0 #####
 
@@ -71,3 +71,4 @@ AFC_1=Y
 # Dump config
 #DumpBuffer=Y
 #DumpFile=./LORA_dump
+

--- a/gateway.c
+++ b/gateway.c
@@ -44,7 +44,7 @@
 #include "udpclient.h"
 #include "lifo_buffer.h"
 
-#define VERSION	"V1.10.6"
+#define VERSION	"V1.11.0"
 bool run = TRUE;
 
 // RFM98

--- a/global.h
+++ b/global.h
@@ -13,12 +13,12 @@ struct TPayload
 	int InUse;
 	int SendToClients;
 	int Channel;
-	
+
 	time_t LastPacketAt;
-	
+
 	char Telemetry[256];
 	char Payload[32];
-	
+
 	char Time[12];
 	unsigned int Counter, LastCounter;
 	double Longitude, Latitude;
@@ -29,26 +29,26 @@ struct TPayload
 	int PacketSNR, PacketRSSI;
 	double Frequency;
 };
- 
-struct TLoRaDevice 
+
+struct TLoRaDevice
 {
 	int    Enabled;
-	
+
 	double Frequency;
     double PPM;
 	double FrequencyOffset;
-    
+
 	double Bandwidth;
 	double CurrentBandwidth;
-		
-	int InUse;    
+
+	int InUse;
 	int DIO0;
 	int DIO5;
-	
+
 	int AFC;					// Enable Automatic Frequency Control
 	double MaxAFCStep;			// Maximum adjustment, in kHz, per packet
 	int AFCTimeout;				// Revert to original frequency if no packets for this period (in seconds)
-	
+
 	int SpeedMode;
 	int Power;
 	int PayloadLength;
@@ -76,7 +76,7 @@ struct TLoRaDevice
 	int IdleUplink;
 	int SSDVUplink;
 	char UplinkMessage[256];
-	
+
 	// Telnet uplink
 	char Telemetry[256];
 	unsigned char PacketID;
@@ -90,8 +90,8 @@ struct TLoRaDevice
 	char HABUplink[256];
 	int HABUplinkCount;
 	int GotHABReply;
-	int GotReply;	
-    
+	int GotReply;
+
     // Chat uplink
     int ChatMode;
     char ChatPayloadID[32];
@@ -99,22 +99,25 @@ struct TLoRaDevice
     char TxChatMessage[200];
     int RxMessageID;
     char RxChatMessage[200];
-	
+
 	// Local data packets
 	int LocalDataCount;
 	char LocalDataBuffer[255];
-	
+
 	// Status
 	int CurrentRSSI;
 	int PacketSNR, PacketRSSI;
 	double FrequencyError;
+
+	// SPI comms
+	int SPIHandle;
 };
- 
-struct TConfig 
- {   
+
+struct TConfig
+ {
 	char Tracker[16];				// Callsign or name of receiver
 	double latitude, longitude, altitude;		// Receiver's location
-     
+
 	int EnableSSDV;
 	int EnableSondehub;
 	int EnableTelemetryLogging;
@@ -152,6 +155,7 @@ struct TConfig
 	char MQTTUser[16];
 	char MQTTPass[32];
 	char MQTTTopic[128];
+	int GPIO_HANDLE;
 };
 
 typedef struct {
@@ -251,7 +255,7 @@ struct TServerInfo
 extern struct TConfig Config;
 extern int SSDVSendArrayIndex;
 extern pthread_mutex_t ssdv_mutex;
- 
+
 void LogMessage( const char *format, ... );
 
 #endif /* _H_Global */

--- a/network.c
+++ b/network.c
@@ -18,7 +18,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
-#include <wiringPi.h>           // Include WiringPi library!
+#include <lgpio.h>
 #include "network.h"
 #include "global.h"
 
@@ -95,23 +95,23 @@ NetworkLoop( void *some_void_ptr )
     {
         if ( HaveAnIPAddress(  ) )
         {
-            digitalWrite( Config.NetworkLED, 1 );
+            lgGpioWrite(Config.GPIO_HANDLE, Config.NetworkLED, 1);
 //          LogMessage("On network :-)\n");
 
             if ( CanSeeTheInternet(  ) )
             {
-                digitalWrite( Config.InternetLED, 1 );
+                lgGpioWrite(Config.GPIO_HANDLE, Config.InternetLED, 1);
 //              LogMessage("On the internet :-)\n");
             }
             else
             {
-                digitalWrite( Config.InternetLED, 0 );
+                lgGpioWrite(Config.GPIO_HANDLE, Config.InternetLED, 0);
 //              LogMessage("Not on internet :-(\n");
             }
         }
         else
         {
-            digitalWrite( Config.NetworkLED, 0 );
+            lgGpioWrite(Config.GPIO_HANDLE, Config.NetworkLED, 0);
 //          LogMessage("No network :-(\n");
         }
 

--- a/ssdv.c
+++ b/ssdv.c
@@ -14,7 +14,7 @@
 #include <math.h>
 #include <pthread.h>
 #include <curl/curl.h>
-#include <wiringPi.h>
+#include <lgpio.h>
 
 #include "urlencode.h"
 #include "base64.h"
@@ -180,16 +180,16 @@ void *SSDVLoop( void *vars )
             if ( j == 50 || ( ( packets == 0 ) && ( j > 0 ) ) )
             {
 				ChannelPrintf(s[0].Channel, 6, 16, "SSDV");
-				
+
                 UploadImagePacket( s, j );
-				
+
 				ChannelPrintf(s[0].Channel, 6, 16, "    ");
 
                 j = 0;
 
                 packets = 0;
             }
-			delay(100);			// Don't eat too much CPU
+            lguSleep(0.1);  // Don't use too much CPU
         }
     }
 


### PR DESCRIPTION
wiringPi is deprecated and removed from the repos. 
Also, it is not usable on a Pi5 due to the new GPIO chip and interface.

Instead, remove the use of wiringPi and use `lgpio` http://abyz.me.uk/lg/lgpio.html.
This allows use on bullseye, bookworm, and in theory, future releases.

* Convert the wiringPi calls
* Change the pin definitions to match the lgpio names instead of wiringPi
* Use lgpio compatible callbacks

Also, the paho mqtt library is now packaged in the repositories, so we can just install that and link against it, instead of building our own from source.

This has been lightly tested locally, and is recieving and parsing packets.
Apologies for the whitespace changes, my IDE got a bit carried away.